### PR TITLE
BUGFIX - AWS Pricing API URL

### DIFF
--- a/aws-emr-cost-calculator
+++ b/aws-emr-cost-calculator
@@ -76,7 +76,7 @@ class Ec2EmrPricing:
     def __init__(self):
         my_session = boto3.session.Session()
         region = my_session.region_name
-        url_base = 'https://pricing.' + region + '.amazonaws.com'
+        url_base = 'https://pricing.us-east-1.amazonaws.com'
 
         index_response = requests.get(url_base + '/offers/v1.0/aws/index.json')
         index = index_response.json()


### PR DESCRIPTION
AWS Pricing API URL does not depend on region.

AWS Price List Service API provides the following two endpoints.

so API URL have to fix as `https://pricing.us-east-1.amazonaws.com` or `https://api.pricing.ap-south-1.amazonaws.com`

https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-pelong.html

I would recommend  'us-east-1' since the endpoint is only one which supports bulk APIs.